### PR TITLE
i18n support and Japanese language support

### DIFF
--- a/public/_locales/ja/messages.json
+++ b/public/_locales/ja/messages.json
@@ -1,0 +1,23 @@
+{
+    "is_signed_today_true": {
+        "message": "ログイン済み"
+    },
+    "is_signed_today_false": {
+        "message": "未ログイン"
+    },
+    "checkbox": {
+        "message": "自動ログインする"
+    },
+    "checkbox_title": {
+        "message": "設定切替"
+    },
+    "open_sign_in_page": {
+        "message": "ログインページ"
+    },
+    "time_picker_description": {
+        "message": "ログイン時間設定"
+    },
+    "sign_time_picker": {
+        "message": "ログイン時間設定"
+    }
+}

--- a/public/_locales/zh_TW/messages.json
+++ b/public/_locales/zh_TW/messages.json
@@ -1,0 +1,24 @@
+{
+    "is_signed_today_true": {
+        "message": "今日已簽到"
+    },
+    "is_signed_today_false": {
+        "message": "今日未簽到"
+    },
+    "checkbox": {
+        "message": "開啟自動簽到"
+    },
+    "checkbox_title" : {
+        "message": "自動簽到開關"
+    },
+    "open_sign_in_page" : {
+        "message": "開啟每日簽到網頁"
+    },
+    "time_picker_description" :{
+        "message": "簽到時間設定"
+    },
+    "sign_time_picker" : {
+        "message": "簽到日期設定"
+    }
+}
+

--- a/public/index.html
+++ b/public/index.html
@@ -12,24 +12,24 @@
 <body>
   <div class="container">
     <div class="switch">
-      <div class="cboxs" title="自動簽到開關">
+      <div class="cboxs" title="自動簽到開關" data-i18n-title="checkbox_title">
         <label class="cbox">
-          開啟自動簽到
+          <span data-i18n-text="checkbox">開啟自動簽到</span>
           <input type="checkbox" checked="checked" id="open">
           <span class="checkmark"></span>
         </label>
       </div>
       <div>
         <a title="開啟每日簽到網頁" href="https://act.hoyolab.com/ys/event/signin-sea-v3/index.html?act_id=e202102251931481"
-          target="_blank">開啟每日簽到網頁</a>
+          target="_blank" data-i18n-text="open_sign_in_page" data-i18n-title="open_sign_in_page">開啟每日簽到網頁</a>
       </div>
     </div>
 
     <div class="setting-box">
       <div class="time-picker">
-        <div>簽到時間設定</div>
+        <div data-i18n-text="time_picker_description">簽到時間設定</div>
         <div id="timepicker">
-          <input type="time" id="sign-time-picker" placeholder="簽到日期設定">
+          <input type="time" id="sign-time-picker" placeholder="簽到日期設定" data-i18n-input="sign_time_picker">
         </div>
       </div>
       <div class="is-sign-today"></div>

--- a/public/index.html
+++ b/public/index.html
@@ -14,7 +14,7 @@
     <div class="switch">
       <div class="cboxs" title="自動簽到開關" data-i18n-title="checkbox_title">
         <label class="cbox">
-          <span data-i18n-text="checkbox">開啟自動簽到</span>
+          <div data-i18n-text="checkbox">開啟自動簽到</div>
           <input type="checkbox" checked="checked" id="open">
           <span class="checkmark"></span>
         </label>
@@ -29,7 +29,7 @@
       <div class="time-picker">
         <div data-i18n-text="time_picker_description">簽到時間設定</div>
         <div id="timepicker">
-          <input type="time" id="sign-time-picker" placeholder="簽到日期設定" data-i18n-input="sign_time_picker">
+          <input type="time" id="sign-time-picker" placeholder="簽到日期設定" data-i18n-placeholder="sign_time_picker">
         </div>
       </div>
       <div class="is-sign-today"></div>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -9,7 +9,7 @@
   "icons": {
     "128": "icon.png"
   },
-  "default_locale": "zh",
+  "default_locale": "zh_TW",
   "action": {
     "default_icon": "icon.png",
     "default_popup": "index.html"

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -9,6 +9,7 @@
   "icons": {
     "128": "icon.png"
   },
+  "default_locale": "zh",
   "action": {
     "default_icon": "icon.png",
     "default_popup": "index.html"

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -39,7 +39,7 @@ function localizeHtmlPage() {
       }
   });
 
-  const input = document.querySelectorAll("[data-i18n-input]") as NodeListOf<HTMLInputElement>;
+  const input = document.querySelectorAll("[data-i18n-placeholder]") as NodeListOf<HTMLInputElement>;
   input.forEach(element => {
       const key = element.getAttribute("data-i18n-placeholder");
       if (key) {

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -39,16 +39,16 @@ function localizeHtmlPage() {
       }
   });
 
-  const i18n_input = document.querySelectorAll("[data-i18n-input]") as NodeListOf<HTMLInputElement>;
-  i18n_input.forEach(element => {
+  const input = document.querySelectorAll("[data-i18n-input]") as NodeListOf<HTMLInputElement>;
+  input.forEach(element => {
       const key = element.getAttribute("data-i18n-placeholder");
       if (key) {
         element.placeholder = chrome.i18n.getMessage(key);
       }
   });
 
-  const i18n_title = document.querySelectorAll("[data-i18n-title]") as NodeListOf<HTMLDivElement>;
-  i18n_title.forEach(element => {
+  const title = document.querySelectorAll("[data-i18n-title]") as NodeListOf<HTMLDivElement>;
+  title.forEach(element => {
       const key = element.getAttribute("data-i18n-title");
       if (key) {
         element.title = chrome.i18n.getMessage(key);

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -78,6 +78,5 @@ window.addEventListener("load", async () => {
   open.checked = Boolean(config.open);
 
   localizeHtmlPage();
-
   checkIsSignToday();
 });

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -23,13 +23,42 @@ async function checkIsSignToday() {
   const config = await getConfig();
   const currentDate = new Date().getDate();
   const el = document.querySelector(".is-sign-today") as HTMLInputElement;
-  el.innerHTML = config.lastDate === currentDate ? "今日已簽到" : "今日未簽到";
+  el.innerHTML = config.lastDate === currentDate
+    ? chrome.i18n.getMessage("is_signed_today_true")
+    : chrome.i18n.getMessage("is_signed_today_false");
+}
+
+/**
+ * 本地化html页面
+ */
+function localizeHtmlPage() {
+  document.querySelectorAll("[data-i18n-text]").forEach(element => {
+      const key = element.getAttribute("data-i18n-text");
+      if (key) {
+        element.textContent = chrome.i18n.getMessage(key);
+      }
+  });
+
+  const i18n_input = document.querySelectorAll("[data-i18n-input]") as NodeListOf<HTMLInputElement>;
+  i18n_input.forEach(element => {
+      const key = element.getAttribute("data-i18n-placeholder");
+      if (key) {
+        element.placeholder = chrome.i18n.getMessage(key);
+      }
+  });
+
+  const i18n_title = document.querySelectorAll("[data-i18n-title]") as NodeListOf<HTMLDivElement>;
+  i18n_title.forEach(element => {
+      const key = element.getAttribute("data-i18n-title");
+      if (key) {
+        element.title = chrome.i18n.getMessage(key);
+      }
+  });
 }
 
 window.addEventListener("load", async () => {
   const open = document.querySelector("#open") as HTMLInputElement; //開啟自動簽到
   const dateInput = document.querySelector("#sign-time-picker") as HTMLInputElement; //日期
-
   open.addEventListener("change", (e) => {
     const el = e.target as HTMLInputElement;
     chrome.storage.sync.set({
@@ -47,6 +76,8 @@ window.addEventListener("load", async () => {
   const m = config.signTime.minutes.toString().padStart(2, "0");
   dateInput.value = `${h}:${m}`;
   open.checked = Boolean(config.open);
+
+  localizeHtmlPage();
 
   checkIsSignToday();
 });


### PR DESCRIPTION
# Apology
- This is my first PR so I could be wrong.
-  I have not been able to review the Japanese text yet, so this is a provisional PR.
- I am a beginner so the implementation may not be the best.

## i18n support

- texts inside  `popup.ts`
  - replaced by directly accessing `chrome.i18n`
- texts inside `popup.html` 
  - add data-tags `data-i18n-title` / `data-i18n-text` / `data-i18n-placeholder` in html
  - replaced by `document.querySelectorAll` and `chrome.i18n` when window is loaded

## messages
I set `"default_locale": "zh_TW"` but is it OK ? 
I am not sure about the choice of locale in the Chinese culture.

